### PR TITLE
Implement autowrapping for some characters

### DIFF
--- a/src/OdeScriptEditor/Hooks/AutoIndent.lua
+++ b/src/OdeScriptEditor/Hooks/AutoIndent.lua
@@ -1,4 +1,6 @@
-local AutoIndent = {}
+local AutoIndent = {
+	RunOrder = 1,
+}
 
 local function testForIndent(codeField, code, start, keyword)
 	if start - keyword:len() <= 0 then

--- a/src/OdeScriptEditor/Hooks/AutoWrap.lua
+++ b/src/OdeScriptEditor/Hooks/AutoWrap.lua
@@ -1,4 +1,6 @@
-local AutoWrap = {}
+local AutoWrap = {
+	RunOrder = 2,
+}
 
 function isCharWhitespace(char)
 	return char == "\n" or char == " "

--- a/src/OdeScriptEditor/Hooks/AutoWrap.lua
+++ b/src/OdeScriptEditor/Hooks/AutoWrap.lua
@@ -4,6 +4,15 @@ function isCharWhitespace(char)
 	return char == "\n" or char == " "
 end
 
+local allowedWraps = {
+	{"\"", "\""},
+	{"'", "'"},
+
+	{"(", ")"},
+	{"[", "]"},
+	{"{", "}"},
+}
+
 function AutoWrap.OnScriptChange(scriptEditor, data)
 	local code = data.Code
 	local cursor = data.Cursor
@@ -18,11 +27,15 @@ function AutoWrap.OnScriptChange(scriptEditor, data)
 		local cursorChar = string.sub(code, lastCharPosition + 1, lastCharPosition + 1)
 		local nextLastChar = string.sub(code, lastCharPosition - 1, lastCharPosition - 1)
 
-		if lastChar == "\"" and lastSelectedString ~= "\"" and lastSelectedString ~= "" and (scriptEditor._LastPreviousChar ~= "\"" or nextLastChar == "\"") then
-			code = string.sub(code, 1, lastCharPosition) .. lastSelectedString .. "\"" .. string.sub(code, lastCharPosition + 1)
+		for _, wrappedCharData in allowedWraps do
+			local startingWrappedChar = wrappedCharData[1]
 
-			codeField.SelectionStart = if lastSelectedString ~= "" then lastCharPosition + 1 else -1
-			data.Cursor += lastSelectedString:len()
+			if lastChar == startingWrappedChar and lastSelectedString ~= startingWrappedChar and lastSelectedString ~= "" and (scriptEditor._LastPreviousChar ~= startingWrappedChar or nextLastChar == startingWrappedChar) then
+				code = string.sub(code, 1, lastCharPosition) .. lastSelectedString .. wrappedCharData[2] .. string.sub(code, lastCharPosition + 1)
+
+				codeField.SelectionStart = if lastSelectedString ~= "" then lastCharPosition + 1 else -1
+				data.Cursor += lastSelectedString:len()
+			end
 		end
 	end
 

--- a/src/OdeScriptEditor/Hooks/AutoWrap.lua
+++ b/src/OdeScriptEditor/Hooks/AutoWrap.lua
@@ -14,6 +14,10 @@ local allowedWraps = {
 }
 
 function AutoWrap.OnScriptChange(scriptEditor, data)
+	if not scriptEditor.AutoWrapEnabled then
+		return
+	end
+
 	local code = data.Code
 	local cursor = data.Cursor
 	local codeField: TextBox = scriptEditor.Background.CodeField

--- a/src/OdeScriptEditor/Hooks/AutoWrap.lua
+++ b/src/OdeScriptEditor/Hooks/AutoWrap.lua
@@ -1,0 +1,32 @@
+local AutoWrap = {}
+
+function isCharWhitespace(char)
+	return char == "\n" or char == " "
+end
+
+function AutoWrap.OnScriptChange(scriptEditor, data)
+	local code = data.Code
+	local cursor = data.Cursor
+	local codeField: TextBox = scriptEditor.Background.CodeField
+
+	if codeField.CursorPosition ~= -1 then
+		-- local lastChar = string.sub(codeField.Text, codeField.CursorPosition - 1, codeField.CursorPosition - 1)
+		local lastCharPosition = codeField.CursorPosition - 1 + cursor
+		local lastChar = string.sub(code, lastCharPosition, lastCharPosition)
+		local lastSelectedString = scriptEditor._LastSelectedString
+
+		local cursorChar = string.sub(code, lastCharPosition + 1, lastCharPosition + 1)
+		local nextLastChar = string.sub(code, lastCharPosition - 1, lastCharPosition - 1)
+
+		if lastChar == "\"" and lastSelectedString ~= "\"" and lastSelectedString ~= "" and (scriptEditor._LastPreviousChar ~= "\"" or nextLastChar == "\"") then
+			code = string.sub(code, 1, lastCharPosition) .. lastSelectedString .. "\"" .. string.sub(code, lastCharPosition + 1)
+
+			codeField.SelectionStart = if lastSelectedString ~= "" then lastCharPosition + 1 else -1
+			data.Cursor += lastSelectedString:len()
+		end
+	end
+
+	data.Code = code
+end
+
+return AutoWrap

--- a/src/OdeScriptEditor/Hooks/AutoWrap.lua
+++ b/src/OdeScriptEditor/Hooks/AutoWrap.lua
@@ -13,10 +13,50 @@ local allowedWraps = {
 	{"{", "}"},
 }
 
+function getLastSelectedString(scriptEditor, autoWrapState)
+	local codeField = scriptEditor.Background.CodeField
+
+	autoWrapState._LastCursorPosition = codeField.CursorPosition
+	autoWrapState._LastSelectionStart = codeField.SelectionStart
+
+	local start = math.min(autoWrapState._LastCursorPosition, autoWrapState._LastSelectionStart)
+	local finish = math.max(autoWrapState._LastCursorPosition, autoWrapState._LastSelectionStart, 1) - 1
+
+	if start == -1 then
+		start = finish + 1
+	end
+
+	autoWrapState._LastSelectedString = string.sub(codeField.Text, start, finish)
+	autoWrapState._LastPreviousChar = string.sub(codeField.Text, start - 1, start - 1)
+end
+
+function AutoWrap.OnScriptEditorInstantiation(scriptEditor)
+	local codeField = scriptEditor.Background.CodeField
+
+	local autoWrapState = {
+		_LastSelectionStart = -1,
+		_LastCursorPosition = -1,
+		_LastSelectedString = "",
+		_LastPreviousChar = "",
+	}
+
+	scriptEditor._AutoWrapState = autoWrapState
+
+	codeField:GetPropertyChangedSignal("CursorPosition"):Connect(function()
+		task.defer(getLastSelectedString, scriptEditor, autoWrapState)
+	end)
+
+	codeField:GetPropertyChangedSignal("SelectionStart"):Connect(function()
+		task.defer(getLastSelectedString, scriptEditor, autoWrapState)
+	end)
+end
+
 function AutoWrap.OnScriptChange(scriptEditor, data)
 	if not scriptEditor.AutoWrapEnabled then
 		return
 	end
+
+	local autoWrapState = scriptEditor._AutoWrapState
 
 	local code = data.Code
 	local cursor = data.Cursor
@@ -26,7 +66,7 @@ function AutoWrap.OnScriptChange(scriptEditor, data)
 		-- local lastChar = string.sub(codeField.Text, codeField.CursorPosition - 1, codeField.CursorPosition - 1)
 		local lastCharPosition = codeField.CursorPosition - 1 + cursor
 		local lastChar = string.sub(code, lastCharPosition, lastCharPosition)
-		local lastSelectedString = scriptEditor._LastSelectedString
+		local lastSelectedString = autoWrapState._LastSelectedString
 
 		local cursorChar = string.sub(code, lastCharPosition + 1, lastCharPosition + 1)
 		local nextLastChar = string.sub(code, lastCharPosition - 1, lastCharPosition - 1)
@@ -34,7 +74,7 @@ function AutoWrap.OnScriptChange(scriptEditor, data)
 		for _, wrappedCharData in allowedWraps do
 			local startingWrappedChar = wrappedCharData[1]
 
-			if lastChar == startingWrappedChar and lastSelectedString ~= startingWrappedChar and lastSelectedString ~= "" and (scriptEditor._LastPreviousChar ~= startingWrappedChar or nextLastChar == startingWrappedChar) then
+			if lastChar == startingWrappedChar and lastSelectedString ~= startingWrappedChar and lastSelectedString ~= "" and (autoWrapState._LastPreviousChar ~= startingWrappedChar or nextLastChar == startingWrappedChar) then
 				code = string.sub(code, 1, lastCharPosition) .. lastSelectedString .. wrappedCharData[2] .. string.sub(code, lastCharPosition + 1)
 
 				codeField.SelectionStart = if lastSelectedString ~= "" then lastCharPosition + 1 else -1

--- a/src/OdeScriptEditor/init.lua
+++ b/src/OdeScriptEditor/init.lua
@@ -368,6 +368,16 @@ local function updateLines(scriptEditor)
 	scriptEditor.Background.RichOverlayContainer.ShiftContainer.RichOverlayLabel.Text = colorify(tabsToSpaces(visibleCodeSegment), scriptEditor.Theme)
 end
 
+local function getSortedHookModules()
+	local hookModules = script.Hooks:GetChildren()
+
+	table.sort(hookModules, function(a, b)
+		return require(a).RunOrder < require(b).RunOrder
+	end)
+
+	return hookModules
+end
+
 local function onCodeFieldEdit(scriptEditor)
 	if not registerEditEvent then
 		registerEditEvent = true
@@ -406,11 +416,7 @@ local function onCodeFieldEdit(scriptEditor)
 	local originalSize = scriptEditor.VisibleLines
 	finalRawCode = fixCodeFieldLines(scriptEditor, #lines)
 
-	local hookModules = script.Hooks:GetChildren()
-
-	-- table.sort(hookModules, function(a, b)
-	-- 	return a:GetAttribute("RunOrder") < b:GetAttribute("RunOrder")
-	-- end)
+	local hookModules = getSortedHookModules()
 
 	local data = {
 		Code = finalRawCode,
@@ -421,7 +427,7 @@ local function onCodeFieldEdit(scriptEditor)
 
 	--runs thru hooks and runs their custom behavior
 	--postprocessing code
-	for _, hookModule in script.Hooks:GetChildren() do
+	for _, hookModule in hookModules do
 		local method = require(hookModule)["OnScriptChange"]
 
 		if method then
@@ -646,7 +652,7 @@ function OdeScriptEditor.Embed(frame: GuiBase2d)
 		end
 	end)
 
-	for _, hookModule in script.Hooks:GetChildren() do
+	for _, hookModule in getSortedHookModules() do
 		local method = require(hookModule)["OnScriptEditorInstantiation"]
 
 		if method then

--- a/src/OdeScriptEditor/init.lua
+++ b/src/OdeScriptEditor/init.lua
@@ -601,6 +601,7 @@ function OdeScriptEditor.Embed(frame: GuiBase2d)
 		OutputScript = nil,
 
 		-- used by AutoWrap
+		AutoWrapEnabled = false,
 		_LastSelectionStart = -1,
 		_LastCursorPosition = -1,
 		_LastSelectedString = "",

--- a/src/OdeScriptEditor/init.lua
+++ b/src/OdeScriptEditor/init.lua
@@ -602,10 +602,6 @@ function OdeScriptEditor.Embed(frame: GuiBase2d)
 
 		-- used by AutoWrap
 		AutoWrapEnabled = false,
-		_LastSelectionStart = -1,
-		_LastCursorPosition = -1,
-		_LastSelectedString = "",
-		_LastPreviousChar = "",
 		ScrollingShift = 0,
 		Destroyed = false,
 
@@ -627,11 +623,6 @@ function OdeScriptEditor.Embed(frame: GuiBase2d)
 
 	codeField:GetPropertyChangedSignal("CursorPosition"):Connect(function()
 		task.defer(moveShiftContainer, scriptEditor)
-		task.defer(getLastSelectedString, scriptEditor)
-	end)
-
-	codeField:GetPropertyChangedSignal("SelectionStart"):Connect(function()
-		task.defer(getLastSelectedString, scriptEditor)
 	end)
 
 	background:GetPropertyChangedSignal("AbsoluteSize"):Connect(function()
@@ -654,6 +645,14 @@ function OdeScriptEditor.Embed(frame: GuiBase2d)
 			scriptEditor:JumpTo(newLineFocused)
 		end
 	end)
+
+	for _, hookModule in script.Hooks:GetChildren() do
+		local method = require(hookModule)["OnScriptEditorInstantiation"]
+
+		if method then
+			method(scriptEditor)
+		end
+	end
 
 	scriptEditor:LoadStringAsync("")
 

--- a/tests/LocalTest.client.lua
+++ b/tests/LocalTest.client.lua
@@ -4,3 +4,4 @@ local OdeFrame = ScriptEditorScreen:WaitForChild("OdeFrame")
 
 local OdeScriptEditor = require(game.ReplicatedStorage.OdeScriptEditor)
 local scriptEditor = OdeScriptEditor.Embed(OdeFrame)
+scriptEditor.AutoWrapEnabled = true


### PR DESCRIPTION
Some code editors support autowrapping, where for example pressing a `"` automatically wraps the selected text into a string. This implements that.