### PR TITLE
Fixes an issue with scrolling in the editor. Without rounding, the wh…

### DIFF
--- a/src/OdeScriptEditor/init.lua
+++ b/src/OdeScriptEditor/init.lua
@@ -644,7 +644,8 @@ function OdeScriptEditor.Embed(frame: GuiBase2d)
 
 	codeField.InputChanged:Connect(function(input)
 		if input.UserInputType == Enum.UserInputType.MouseWheel then
-			local newLineFocused = math.clamp(scriptEditor.LineFocused - input.Position.Z*3, 1, #string.split(scriptEditor.RawSource, "\n"))
+			local roundZ = math.round(input.Position.Z)
+			local newLineFocused = math.clamp(scriptEditor.LineFocused - roundZ*3, 1, #string.split(scriptEditor.RawSource, "\n"))
 
 			codeField:ReleaseFocus()
 


### PR DESCRIPTION
Fixes an issue with scrolling in the editor. Without rounding, the whole editor becomes blank after scrolling. Seems to be an issue only when the game is published. Works fine without it while inside of Roblox Studio